### PR TITLE
Make WebGLCircle render a buffer instead of a single point

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { unstable_deferredUpdates } from "react-dom";
 class App extends Component {
   state = {
     circles: [],
+    colors: [],
   }
 
   constructor() {
@@ -37,7 +38,10 @@ class App extends Component {
     canvasY = event.pageY - totalOffsetY;
 
     unstable_deferredUpdates(() => {
-      this.setState({circles: this.state.circles.concat([[canvasX, canvasY]])})
+      this.setState({
+        circles: this.state.circles.concat([[canvasX, canvasY]]),
+        colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]])
+      })
     })
 
   }
@@ -68,7 +72,10 @@ class App extends Component {
     canvasX = event.pageX - totalOffsetX;
     canvasY = event.pageY - totalOffsetY;
 
-    this.setState({circles: this.state.circles.concat([[canvasX, canvasY]])})
+    this.setState({
+      circles: this.state.circles.concat([[canvasX, canvasY]]),
+      colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]])
+    })
   }
 
   render() {
@@ -81,7 +88,7 @@ class App extends Component {
           <WebGLCircle
               vertices={_.flatten(this.state.circles)}
               radius={4}
-              color={[0, 0, 0, 1]}
+              colors={_.flatten(this.state.colors)}
           />
       </WebGLCanvas>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -78,16 +78,11 @@ class App extends Component {
          onMouseUp={this.handleMouseUp}
          onMouseMove={this.handleMouseMove}
         >
-          {
-            (_.uniq(this.state.circles)).map(([x, y]) =>
-              <WebGLCircle
-                x={x}
-                y={y}
-                radius={4}
-                color={[0, 0, 0, 1]}
-              />
-            )
-          }
+          <WebGLCircle
+              vertices={_.flatten(this.state.circles)}
+              radius={4}
+              color={[0, 0, 0, 1]}
+          />
       </WebGLCanvas>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ class App extends Component {
   state = {
     circles: [],
     colors: [],
+    radii: [],
   }
 
   constructor() {
@@ -40,7 +41,8 @@ class App extends Component {
     unstable_deferredUpdates(() => {
       this.setState({
         circles: this.state.circles.concat([[canvasX, canvasY]]),
-        colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]])
+        colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]]),
+        radii: this.state.radii.concat([[Math.random() * 32.0]])
       })
     })
 
@@ -74,7 +76,8 @@ class App extends Component {
 
     this.setState({
       circles: this.state.circles.concat([[canvasX, canvasY]]),
-      colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]])
+      colors: this.state.colors.concat([[Math.random(), Math.random(), Math.random(), 1.0]]),
+      radii: this.state.radii.concat([[Math.random() * 32.0]])
     })
   }
 
@@ -87,7 +90,7 @@ class App extends Component {
         >
           <WebGLCircle
               vertices={_.flatten(this.state.circles)}
-              radius={4}
+              radii={_.flatten(this.state.radii)}
               colors={_.flatten(this.state.colors)}
           />
       </WebGLCanvas>

--- a/src/components/WebGLCircle.js
+++ b/src/components/WebGLCircle.js
@@ -12,7 +12,7 @@ class WebGLCircle extends React.Component {
   static propTypes = {
     colors: PropTypes.array.isRequired,
     vartices: PropTypes.array.isRequired,
-    radius: PropTypes.number.isRequired,
+    radii: PropTypes.array.isRequired,
   }
 
   color(gl, colors) {
@@ -34,6 +34,25 @@ class WebGLCircle extends React.Component {
     gl.vertexAttribPointer(this.colorAttributeLocation, size, type, normalize, stride, offset);
   }
 
+  radius(gl, radii) {
+
+    // Enable color vertex attribute
+    gl.enableVertexAttribArray(this.radiusAttributeLocation);
+
+    // Bind the color buffer
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.radiusBuffer);
+
+    // Bind the color buffer data
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(radii), gl.STATIC_DRAW);
+
+    const size = 1;
+    const type = gl.FLOAT;
+    const normalize = false;
+    const stride = 0;
+    const offset = 0;
+    gl.vertexAttribPointer(this.radiusAttributeLocation, size, type, normalize, stride, offset);
+  }
+
   // Fills the buffer with the values that define a circle.
   circle(gl, vertices) {
 
@@ -47,14 +66,16 @@ class WebGLCircle extends React.Component {
   glWillMount(canvas, gl, program) {
     this.positionAttributeLocation = gl.getAttribLocation(program, "vPosition");
     this.colorAttributeLocation = gl.getAttribLocation(program, "a_color");
+    this.radiusAttributeLocation = gl.getAttribLocation(program, "a_radius");
     this.resolutionUniformLocation = gl.getUniformLocation(program, "u_resolution");
-    this.radiusUniformLocation = gl.getUniformLocation(program, "u_radius");
     this.positionBuffer = gl.createBuffer();
     this.colorBuffer = gl.createBuffer();
-    // gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+    this.radiusBuffer = gl.createBuffer();
   }
 
   glRender(canvas, gl, props) {
+
+    this.radius(gl, props.radii);
 
     this.color(gl, props.colors);
 
@@ -83,9 +104,6 @@ class WebGLCircle extends React.Component {
 
     this.circle(gl, props.vertices);
 
-    // Set the radius
-    gl.uniform1f(this.radiusUniformLocation, props.radius);
-
     // Draw the rectangle.
     gl.drawArrays(gl.POINTS, 0, props.vertices.length / 2);
   }
@@ -96,13 +114,13 @@ class WebGLCircle extends React.Component {
         <VertexShader>{`
           attribute vec2 vPosition;
           uniform vec2 u_resolution;
-          uniform float u_radius;
+          attribute float a_radius;
           attribute vec4 a_color;
           varying vec4 v_color;
 
           void main(void)
           {
-            gl_PointSize = u_radius;
+            gl_PointSize = a_radius;
 
             // convert the position from pixels to 0.0 to 1.0
             vec2 zeroToOne = vPosition / u_resolution;

--- a/src/components/WebGLCircle.js
+++ b/src/components/WebGLCircle.js
@@ -11,19 +11,18 @@ import glComponent from "../lib/glComponent";
 class WebGLCircle extends React.Component {
   static propTypes = {
     color: PropTypes.array.isRequired,
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
+    points: PropTypes.array.isRequired,
     radius: PropTypes.number.isRequired,
   }
 
   // Fills the buffer with the values that define a circle.
-  circle(gl, x, y) {
+  circle(gl, vertices) {
 
     // NOTE: gl.bufferData(gl.ARRAY_BUFFER, ...) will affect
     // whatever buffer is bound to the `ARRAY_BUFFER` bind point
     // but so far we only have one buffer. If we had more than one
     // buffer we'd want to bind that buffer to `ARRAY_BUFFER` first.
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([x, y]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
   }
 
   glWillMount(canvas, gl, program) {
@@ -60,7 +59,7 @@ class WebGLCircle extends React.Component {
       offset
     );
 
-    this.circle(gl, props.x, props.y);
+    this.circle(gl, props.vertices);
 
     // Set the radius
     gl.uniform1f(this.radiusUniformLocation, props.radius);
@@ -71,7 +70,7 @@ class WebGLCircle extends React.Component {
     gl.uniform4f(this.colorUniformLocation, r, g, b, a);
 
     // Draw the rectangle.
-    gl.drawArrays(gl.POINTS, 0, 1);
+    gl.drawArrays(gl.POINTS, 0, props.vertices.length / 2);
   }
 
   render() {


### PR DESCRIPTION
Basically we replace the x and y props with an array of vertices, in the form of a flattened array of interlaced x and y coords, we then pass that array into gl.bufferData instead of just a single point ([x, y]).